### PR TITLE
A version that preserves Attribute (and TrueColorAttribute) as a struct

### DIFF
--- a/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/CursesDriver/CursesDriver.cs
@@ -60,7 +60,7 @@ namespace Terminal.Gui {
 				rune = MakePrintable (rune);
 				Curses.addch ((int)(uint)rune);
 				contents [crow, ccol, 0] = (int)(uint)rune;
-				contents [crow, ccol, 1] = currentAttribute;
+				contents [crow, ccol, 1] = currentAttribute.Value;
 				contents [crow, ccol, 2] = 1;
 			} else
 				needMove = true;
@@ -122,12 +122,12 @@ namespace Terminal.Gui {
 
 		public override void UpdateScreen () => window.redrawwin ();
 
-		Attribute currentAttribute;
+		IAttribute currentAttribute;
 
-		public override void SetAttribute (Attribute c)
+		public override void SetAttribute (IAttribute c)
 		{
 			currentAttribute = c;
-			Curses.attrset (currentAttribute);
+			Curses.attrset (currentAttribute.Value);
 		}
 
 		public Curses.Window window;
@@ -140,7 +140,7 @@ namespace Terminal.Gui {
 		/// <param name="foreground">Contains the curses attributes for the foreground (color, plus any attributes)</param>
 		/// <param name="background">Contains the curses attributes for the background (color, plus any attributes)</param>
 		/// <returns></returns>
-		public static Attribute MakeColor (short foreground, short background)
+		public static IAttribute MakeColor (short foreground, short background)
 		{
 			var v = (short)((int)foreground | background << 4);
 			//Curses.InitColorPair (++last_color_pair, foreground, background);
@@ -154,7 +154,7 @@ namespace Terminal.Gui {
 				background: MapCursesColor (background));
 		}
 
-		static Attribute MakeColor (Color fore, Color back)
+		static IAttribute MakeColor (Color fore, Color back)
 		{
 			return MakeColor ((short)MapColor (fore), (short)MapColor (back));
 		}
@@ -171,10 +171,10 @@ namespace Terminal.Gui {
 				bool bold = (f & 0x8) != 0;
 				f &= 0x7;
 
-				v = MakeColor ((short)f, (short)b) | (bold ? Curses.A_BOLD : 0);
+				v = MakeColor ((short)f, (short)b).Value | (bold ? Curses.A_BOLD : 0);
 				colorPairs [(int)foreground, (int)background] = v | 0x1000;
 			}
-			SetAttribute (v & 0xffff);
+			SetAttribute (new Attribute(v & 0xffff));
 		}
 
 		Dictionary<int, int> rawPairs = new Dictionary<int, int> ();
@@ -182,10 +182,10 @@ namespace Terminal.Gui {
 		{
 			int key = ((ushort)foreColorId << 16) | (ushort)backgroundColorId;
 			if (!rawPairs.TryGetValue (key, out var v)) {
-				v = MakeColor (foreColorId, backgroundColorId);
+				v = MakeColor (foreColorId, backgroundColorId).Value;
 				rawPairs [key] = v;
 			}
-			SetAttribute (v);
+			SetAttribute (new Attribute(v));
 		}
 
 		static Key MapCursesKey (int cursesKey)
@@ -905,31 +905,31 @@ namespace Terminal.Gui {
 				Colors.Error.HotFocus = MakeColor (Color.Black, Color.Red);
 				Colors.Error.Disabled = MakeColor (Color.DarkGray, Color.White);
 			} else {
-				Colors.TopLevel.Normal = Curses.COLOR_GREEN;
-				Colors.TopLevel.Focus = Curses.COLOR_WHITE;
-				Colors.TopLevel.HotNormal = Curses.COLOR_YELLOW;
-				Colors.TopLevel.HotFocus = Curses.COLOR_YELLOW;
-				Colors.TopLevel.Disabled = Curses.A_BOLD | Curses.COLOR_GRAY;
-				Colors.Base.Normal = Curses.A_NORMAL;
-				Colors.Base.Focus = Curses.A_REVERSE;
-				Colors.Base.HotNormal = Curses.A_BOLD;
-				Colors.Base.HotFocus = Curses.A_BOLD | Curses.A_REVERSE;
-				Colors.Base.Disabled = Curses.A_BOLD | Curses.COLOR_GRAY;
-				Colors.Menu.Normal = Curses.A_REVERSE;
-				Colors.Menu.Focus = Curses.A_NORMAL;
-				Colors.Menu.HotNormal = Curses.A_BOLD;
-				Colors.Menu.HotFocus = Curses.A_NORMAL;
-				Colors.Menu.Disabled = Curses.A_BOLD | Curses.COLOR_GRAY;
-				Colors.Dialog.Normal = Curses.A_REVERSE;
-				Colors.Dialog.Focus = Curses.A_NORMAL;
-				Colors.Dialog.HotNormal = Curses.A_BOLD;
-				Colors.Dialog.HotFocus = Curses.A_NORMAL;
-				Colors.Dialog.Disabled = Curses.A_BOLD | Curses.COLOR_GRAY;
-				Colors.Error.Normal = Curses.A_BOLD;
-				Colors.Error.Focus = Curses.A_BOLD | Curses.A_REVERSE;
-				Colors.Error.HotNormal = Curses.A_BOLD | Curses.A_REVERSE;
-				Colors.Error.HotFocus = Curses.A_REVERSE;
-				Colors.Error.Disabled = Curses.A_BOLD | Curses.COLOR_GRAY;
+				Colors.TopLevel.Normal = new Attribute(Curses.COLOR_GREEN);
+				Colors.TopLevel.Focus = new Attribute (Curses.COLOR_WHITE);
+				Colors.TopLevel.HotNormal = new Attribute (Curses.COLOR_YELLOW);
+				Colors.TopLevel.HotFocus = new Attribute (Curses.COLOR_YELLOW);
+				Colors.TopLevel.Disabled = new Attribute (Curses.A_BOLD | Curses.COLOR_GRAY);
+				Colors.Base.Normal = new Attribute (Curses.A_NORMAL);
+				Colors.Base.Focus = new Attribute (Curses.A_REVERSE);
+				Colors.Base.HotNormal = new Attribute (Curses.A_BOLD);
+				Colors.Base.HotFocus = new Attribute (Curses.A_BOLD | Curses.A_REVERSE);
+				Colors.Base.Disabled = new Attribute (Curses.A_BOLD | Curses.COLOR_GRAY);
+				Colors.Menu.Normal = new Attribute (Curses.A_REVERSE);
+				Colors.Menu.Focus = new Attribute (Curses.A_NORMAL);
+				Colors.Menu.HotNormal = new Attribute (Curses.A_BOLD);
+				Colors.Menu.HotFocus = new Attribute (Curses.A_NORMAL);
+				Colors.Menu.Disabled = new Attribute (Curses.A_BOLD | Curses.COLOR_GRAY);
+				Colors.Dialog.Normal = new Attribute (Curses.A_REVERSE);
+				Colors.Dialog.Focus = new Attribute (Curses.A_NORMAL);
+				Colors.Dialog.HotNormal = new Attribute (Curses.A_BOLD);
+				Colors.Dialog.HotFocus = new Attribute (Curses.A_NORMAL);
+				Colors.Dialog.Disabled = new Attribute (Curses.A_BOLD | Curses.COLOR_GRAY);
+				Colors.Error.Normal = new Attribute (Curses.A_BOLD);
+				Colors.Error.Focus = new Attribute (Curses.A_BOLD | Curses.A_REVERSE);
+				Colors.Error.HotNormal = new Attribute (Curses.A_BOLD | Curses.A_REVERSE);
+				Colors.Error.HotFocus = new Attribute (Curses.A_REVERSE);
+				Colors.Error.Disabled = new Attribute (Curses.A_BOLD | Curses.COLOR_GRAY);
 			}
 		}
 
@@ -942,7 +942,7 @@ namespace Terminal.Gui {
 					//Curses.attrset (Colors.TopLevel.Normal);
 					//Curses.addch ((int)(uint)' ');
 					contents [row, col, 0] = ' ';
-					contents [row, col, 1] = Colors.TopLevel.Normal;
+					contents [row, col, 1] = Colors.TopLevel.Normal.Value;
 					contents [row, col, 2] = 0;
 				}
 			}
@@ -1046,7 +1046,7 @@ namespace Terminal.Gui {
 			throw new ArgumentException ("Invalid curses color code");
 		}
 
-		public override Attribute MakeAttribute (Color fore, Color back)
+		public override IAttribute MakeAttribute (Color fore, Color back)
 		{
 			var f = MapColor (fore);
 			//return MakeColor ((short)(f & 0xffff), (short)MapColor (back)) | ((f & Curses.A_BOLD) != 0 ? Curses.A_BOLD : 0);
@@ -1093,7 +1093,7 @@ namespace Terminal.Gui {
 			//Curses.mouseinterval (lastMouseInterval);
 		}
 
-		public override Attribute GetAttribute ()
+		public override IAttribute GetAttribute ()
 		{
 			return currentAttribute;
 		}

--- a/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/FakeDriver/FakeDriver.cs
@@ -46,7 +46,7 @@ namespace Terminal.Gui {
 			for (int r = 0; r < rows; r++) {
 				for (int c = 0; c < cols; c++) {
 					contents [r, c, 0] = ' ';
-					contents [r, c, 1] = MakeColor (ConsoleColor.Gray, ConsoleColor.Black);
+					contents [r, c, 1] = MakeColor (ConsoleColor.Gray, ConsoleColor.Black).Value;
 					contents [r, c, 2] = 0;
 				}
 			}
@@ -102,7 +102,7 @@ namespace Terminal.Gui {
 					needMove = false;
 				}
 				contents [crow, ccol, 0] = (int)(uint)rune;
-				contents [crow, ccol, 1] = currentAttribute;
+				contents [crow, ccol, 1] = currentAttribute.Value;
 				contents [crow, ccol, 2] = 1;
 				dirtyLine [crow] = true;
 			} else
@@ -129,7 +129,7 @@ namespace Terminal.Gui {
 			FakeConsole.Clear ();
 		}
 
-		static Attribute MakeColor (ConsoleColor f, ConsoleColor b)
+		static IAttribute MakeColor (ConsoleColor f, ConsoleColor b)
 		{
 			// Encode the colors into the int value.
 			return new Attribute (
@@ -194,7 +194,7 @@ namespace Terminal.Gui {
 			//MockConsole.Clear ();
 		}
 
-		public override Attribute MakeAttribute (Color fore, Color back)
+		public override IAttribute MakeAttribute (Color fore, Color back)
 		{
 			return MakeColor ((ConsoleColor)fore, (ConsoleColor)back);
 		}
@@ -266,8 +266,8 @@ namespace Terminal.Gui {
 			FakeConsole.CursorLeft = savedCol;
 		}
 
-		Attribute currentAttribute;
-		public override void SetAttribute (Attribute c)
+		IAttribute currentAttribute;
+		public override void SetAttribute (IAttribute c)
 		{
 			currentAttribute = c;
 		}
@@ -419,7 +419,7 @@ namespace Terminal.Gui {
 			keyUpHandler (new KeyEvent (map, keyModifiers));
 		}
 
-		public override Attribute GetAttribute ()
+		public override IAttribute GetAttribute ()
 		{
 			return currentAttribute;
 		}
@@ -539,7 +539,7 @@ namespace Terminal.Gui {
 				for (int row = 0; row < rows; row++) {
 					for (int c = 0; c < cols; c++) {
 						contents [row, c, 0] = ' ';
-						contents [row, c, 1] = (ushort)Colors.TopLevel.Normal;
+						contents [row, c, 1] = (ushort)Colors.TopLevel.Normal.Value;
 						contents [row, c, 2] = 0;
 						dirtyLine [row] = true;
 					}

--- a/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
+++ b/Terminal.Gui/ConsoleDrivers/WindowsDriver.cs
@@ -79,7 +79,7 @@ namespace Terminal.Gui {
 				foreach (var info in charInfoBuffer) {
 					ci[i++] = new CharInfo () {
 						Char = new CharUnion () { UnicodeChar = info.Char },
-						Attributes = (ushort)(int)info.Attribute
+						Attributes = (ushort)(int)info.Attribute.Value
 					};
 				}
 
@@ -103,7 +103,7 @@ namespace Terminal.Gui {
 
 			stringBuilder.Append (SafeCursor);
 
-			Attribute prev = null;
+			IAttribute prev = null;
 			foreach (var info in charInfoBuffer) {
 				var attr = info.Attribute;
 
@@ -124,7 +124,7 @@ namespace Terminal.Gui {
 						stringBuilder.Append (tca.TrueColorBackground.Blue);
 						stringBuilder.Append ('m');
 					} else {
-						var cc = (int)attr;
+						var cc = attr.Value;
 						stringBuilder.Append (SendColorFg);
 						stringBuilder.Append (TrueColor.Code4ToCode8 (cc % 16));
 						stringBuilder.Append (SendColorBg);
@@ -568,7 +568,7 @@ namespace Terminal.Gui {
 
 		public struct ExtendedCharInfo {
 			public char Char { get; set; }
-			public Attribute Attribute { get; set; }
+			public IAttribute Attribute { get; set; }
 		}
 
 		[StructLayout (LayoutKind.Sequential)]
@@ -1556,7 +1556,7 @@ namespace Terminal.Gui {
 					OutputBuffer [position].Attribute = Colors.TopLevel.Normal;
 					OutputBuffer [position].Char = ' ';
 					contents [row, col, 0] = OutputBuffer [position].Char;
-					contents [row, col, 1] = OutputBuffer [position].Attribute;
+					contents [row, col, 1] = OutputBuffer [position].Attribute.Value;
 					contents [row, col, 2] = 0;
 				}
 			}
@@ -1578,7 +1578,7 @@ namespace Terminal.Gui {
 				OutputBuffer [position].Attribute = currentAttribute;
 				OutputBuffer [position].Char = (char)rune;
 				contents [crow, ccol, 0] = (int)(uint)rune;
-				contents [crow, ccol, 1] = currentAttribute;
+				contents [crow, ccol, 1] = currentAttribute.Value;
 				contents [crow, ccol, 2] = 1;
 				WindowsConsole.SmallRect.Update (ref damageRegion, (short)ccol, (short)crow);
 			}
@@ -1605,9 +1605,9 @@ namespace Terminal.Gui {
 				AddRune (rune);
 		}
 
-		Attribute currentAttribute;
+		IAttribute currentAttribute;
 
-		public override void SetAttribute (Attribute c)
+		public override void SetAttribute (IAttribute c)
 		{
 			currentAttribute = c;
 		}
@@ -1622,7 +1622,7 @@ namespace Terminal.Gui {
 			);
 		}
 
-		public override Attribute MakeAttribute (Color fore, Color back)
+		public override IAttribute MakeAttribute (Color fore, Color back)
 		{
 			return MakeColor ((ConsoleColor)fore, (ConsoleColor)back);
 		}
@@ -1688,7 +1688,7 @@ namespace Terminal.Gui {
 			WinConsole = null;
 		}
 
-		public override Attribute GetAttribute ()
+		public override IAttribute GetAttribute ()
 		{
 			return currentAttribute;
 		}

--- a/Terminal.Gui/Core/Border.cs
+++ b/Terminal.Gui/Core/Border.cs
@@ -440,7 +440,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// Gets or sets the color for the <see cref="Border"/>
 		/// </summary>
-		public Attribute Effect3DBrush { get; set; }
+		public IAttribute Effect3DBrush { get; set; } = new Attribute (-1);
 
 		/// <summary>
 		/// Calculate the sum of the <see cref="Padding"/> and the <see cref="BorderThickness"/>
@@ -864,11 +864,11 @@ namespace Terminal.Gui {
 			driver.SetAttribute (savedAttribute);
 		}
 
-		private Attribute GetEffect3DBrush ()
+		private IAttribute GetEffect3DBrush ()
 		{
-			return Effect3DBrush == null
+			return Effect3DBrush.Value == -1
 				? new Attribute (Color.Gray, Color.DarkGray)
-				: (Attribute)Effect3DBrush;
+				: Effect3DBrush;
 		}
 
 		private void AddRuneAt (ConsoleDriver driver, int col, int row, Rune ch)

--- a/Terminal.Gui/Core/Graphs/Annotations.cs
+++ b/Terminal.Gui/Core/Graphs/Annotations.cs
@@ -173,7 +173,7 @@ namespace Terminal.Gui.Graphs {
 			foreach (var entry in entries) {
 
 				if (entry.Item1.Color != null) {
-					Application.Driver.SetAttribute (entry.Item1.Color.Value);
+					Application.Driver.SetAttribute (new Attribute(entry.Item1.Color.Value));
 				} else {
 					graph.SetDriverColorToGraphColor ();
 				}
@@ -226,7 +226,7 @@ namespace Terminal.Gui.Graphs {
 		/// <summary>
 		/// Color for the line that connects points
 		/// </summary>
-		public Attribute LineColor { get; set; }
+		public IAttribute LineColor { get; set; }
 
 		/// <summary>
 		/// The symbol that gets drawn along the line, defaults to '.'

--- a/Terminal.Gui/Core/Graphs/GraphCellToRender.cs
+++ b/Terminal.Gui/Core/Graphs/GraphCellToRender.cs
@@ -15,7 +15,7 @@ namespace Terminal.Gui.Graphs {
 		/// <summary>
 		/// Optional color to render the <see cref="Rune"/> with
 		/// </summary>
-		public Attribute Color { get; set; }
+		public IAttribute Color { get; set; } = new Attribute (-1);
 
 		/// <summary>
 		/// Creates instance and sets <see cref="Rune"/> with default graph coloring
@@ -30,7 +30,7 @@ namespace Terminal.Gui.Graphs {
 		/// </summary>
 		/// <param name="rune"></param>
 		/// <param name="color"></param>
-		public GraphCellToRender (Rune rune, Attribute color) : this (rune)
+		public GraphCellToRender (Rune rune, IAttribute color) : this (rune)
 		{
 			Color = color;
 		}

--- a/Terminal.Gui/Core/Graphs/Series.cs
+++ b/Terminal.Gui/Core/Graphs/Series.cs
@@ -43,7 +43,7 @@ namespace Terminal.Gui.Graphs {
 		public void DrawSeries (GraphView graph, Rect drawBounds, RectangleF graphBounds)
 		{
 			if (Fill.Color != null) {
-				Application.Driver.SetAttribute (Fill.Color.Value);
+				Application.Driver.SetAttribute (Fill.Color);
 			}
 
 			foreach (var p in Points.Where (p => graphBounds.Contains (p))) {
@@ -84,7 +84,7 @@ namespace Terminal.Gui.Graphs {
 		/// <param name="barsEvery">How far appart to put each category (in graph space)</param>
 		/// <param name="spacing">How much spacing between bars in a category (should be less than <paramref name="barsEvery"/>/<paramref name="numberOfBarsPerCategory"/>)</param>
 		/// <param name="colors">Array of colors that define bar color in each category.  Length must match <paramref name="numberOfBarsPerCategory"/></param>
-		public MultiBarSeries (int numberOfBarsPerCategory, float barsEvery, float spacing, Attribute [] colors = null)
+		public MultiBarSeries (int numberOfBarsPerCategory, float barsEvery, float spacing, IAttribute [] colors = null)
 		{
 			subSeries = new BarSeries [numberOfBarsPerCategory];
 
@@ -173,7 +173,7 @@ namespace Terminal.Gui.Graphs {
 		/// <summary>
 		/// Overrides the <see cref="Bar.Fill"/> with a fixed color
 		/// </summary>
-		public Attribute OverrideBarColor { get; set; }
+		public IAttribute OverrideBarColor { get; set; } = new Attribute (-1);
 
 		/// <summary>
 		/// True to draw <see cref="Bar.Text"/> along the axis under the bar.  Defaults
@@ -188,7 +188,7 @@ namespace Terminal.Gui.Graphs {
 		/// <returns></returns>
 		protected virtual GraphCellToRender AdjustColor (GraphCellToRender graphCellToRender)
 		{
-			if (OverrideBarColor != null) {
+			if (OverrideBarColor.Value != -1) {
 				graphCellToRender.Color = OverrideBarColor;
 			}
 
@@ -274,8 +274,8 @@ namespace Terminal.Gui.Graphs {
 		{
 			var adjusted = AdjustColor (beingDrawn.Fill);
 
-			if (adjusted.Color != null) {
-				Application.Driver.SetAttribute (adjusted.Color.Value);
+			if (adjusted.Color.Value != -1) {
+				Application.Driver.SetAttribute (adjusted.Color);
 			}
 
 			graph.DrawLine (start, end, adjusted.Rune);

--- a/Terminal.Gui/Core/TextFormatter.cs
+++ b/Terminal.Gui/Core/TextFormatter.cs
@@ -118,7 +118,7 @@ namespace Terminal.Gui {
 		TextAlignment textAlignment;
 		VerticalTextAlignment textVerticalAlignment;
 		TextDirection textDirection;
-		Attribute textColor = -1;
+		Attribute textColor = new Attribute(-1);
 		bool needsFormat;
 		Key hotKey;
 		Size size;
@@ -346,7 +346,7 @@ namespace Terminal.Gui {
 		}
 
 		/// <summary>
-		/// Gets or sets whether the <see cref="TextFormatter"/> needs to format the text when <see cref="Draw(Rect, Attribute, Attribute)"/> is called.
+		/// Gets or sets whether the <see cref="TextFormatter"/> needs to format the text when <see cref="Draw(Rect, IAttribute, IAttribute)"/> is called.
 		/// If it is <c>false</c> when Draw is called, the Draw call will be faster.
 		/// </summary>
 		/// <remarks>
@@ -925,7 +925,7 @@ namespace Terminal.Gui {
 		/// <param name="bounds">Specifies the screen-relative location and maximum size for drawing the text.</param>
 		/// <param name="normalColor">The color to use for all text except the hotkey</param>
 		/// <param name="hotColor">The color to use to draw the hotkey</param>
-		public void Draw (Rect bounds, Attribute normalColor, Attribute hotColor)
+		public void Draw (Rect bounds, IAttribute normalColor, IAttribute hotColor)
 		{
 			// With this check, we protect against subclasses with overrides of Text (like Button)
 			if (ustring.IsNullOrEmpty (text)) {

--- a/Terminal.Gui/Core/Trees/Branch.cs
+++ b/Terminal.Gui/Core/Trees/Branch.cs
@@ -90,7 +90,7 @@ namespace Terminal.Gui.Trees {
 		{
 			// true if the current line of the tree is the selected one and control has focus
 			bool isSelected = tree.IsSelected (Model) && tree.HasFocus;
-			Attribute lineColor = isSelected ? colorScheme.Focus : colorScheme.Normal;
+			IAttribute lineColor = isSelected ? colorScheme.Focus : colorScheme.Normal;
 
 			driver.SetAttribute (lineColor);
 
@@ -117,7 +117,7 @@ namespace Terminal.Gui.Trees {
 
 			// pick color for expanded symbol
 			if (tree.Style.ColorExpandSymbol || tree.Style.InvertExpandSymbolColors) {
-				Attribute color;
+				IAttribute color;
 
 				if (tree.Style.ColorExpandSymbol) {
 					color = isSelected ? tree.ColorScheme.HotFocus : tree.ColorScheme.HotNormal;

--- a/Terminal.Gui/Core/View.cs
+++ b/Terminal.Gui/Core/View.cs
@@ -1145,7 +1145,7 @@ namespace Terminal.Gui {
 		/// <para>The hotkey is any character following the hotkey specifier, which is the underscore ('_') character by default.</para>
 		/// <para>The hotkey specifier can be changed via <see cref="HotKeySpecifier"/></para>
 		/// </remarks>
-		public void DrawHotString (ustring text, Attribute hotColor, Attribute normalColor)
+		public void DrawHotString (ustring text, IAttribute hotColor, IAttribute normalColor)
 		{
 			var hotkeySpec = HotKeySpecifier == (Rune)0xffff ? (Rune)'_' : HotKeySpecifier;
 			Application.Driver.SetAttribute (normalColor);
@@ -2723,7 +2723,7 @@ namespace Terminal.Gui {
 		/// </summary>
 		/// <returns><see cref="ColorScheme.Normal"/> if <see cref="Enabled"/> is <see langword="true"/>
 		/// or <see cref="ColorScheme.Disabled"/> if <see cref="Enabled"/> is <see langword="false"/></returns>
-		public Attribute GetNormalColor ()
+		public IAttribute GetNormalColor ()
 		{
 			return Enabled ? ColorScheme.Normal : ColorScheme.Disabled;
 		}

--- a/Terminal.Gui/Views/GraphView.cs
+++ b/Terminal.Gui/Views/GraphView.cs
@@ -63,7 +63,7 @@ namespace Terminal.Gui {
 		/// <summary>
 		/// The color of the background of the graph and axis/labels
 		/// </summary>
-		public Attribute GraphColor { get; set; }
+		public IAttribute GraphColor { get; set; }
 
 		/// <summary>
 		/// Creates a new graph with a 1 to 1 graph space with absolute layout

--- a/Terminal.Gui/Views/HexView.cs
+++ b/Terminal.Gui/Views/HexView.cs
@@ -200,7 +200,7 @@ namespace Terminal.Gui {
 		///<inheritdoc/>
 		public override void Redraw (Rect bounds)
 		{
-			Attribute currentAttribute;
+			IAttribute currentAttribute;
 			var current = ColorScheme.Focus;
 			Driver.SetAttribute (current);
 			Move (0, 0);
@@ -212,8 +212,8 @@ namespace Terminal.Gui {
 			Source.Position = displayStart;
 			var n = source.Read (data, 0, data.Length);
 
-			int activeColor = ColorScheme.HotNormal;
-			int trackingColor = ColorScheme.HotFocus;
+			var activeColor = ColorScheme.HotNormal;
+			var trackingColor = ColorScheme.HotFocus;
 
 			for (int line = 0; line < frame.Height; line++) {
 				var lineRect = new Rect (0, line, frame.Width, 1);
@@ -266,7 +266,7 @@ namespace Terminal.Gui {
 				}
 			}
 
-			void SetAttribute (Attribute attribute)
+			void SetAttribute (IAttribute attribute)
 			{
 				if (currentAttribute != attribute) {
 					currentAttribute = attribute;

--- a/Terminal.Gui/Views/ListView.cs
+++ b/Terminal.Gui/Views/ListView.cs
@@ -959,7 +959,7 @@ namespace Terminal.Gui {
 		/// The <see cref="Attribute"/> used by current row or
 		/// null to maintain the current attribute.
 		/// </summary>
-		public Attribute RowAttribute { get; set; }
+		public IAttribute RowAttribute { get; set; }
 
 		/// <summary>
 		/// Initializes with the current row.

--- a/Terminal.Gui/Views/Menu.cs
+++ b/Terminal.Gui/Views/Menu.cs
@@ -434,7 +434,7 @@ namespace Terminal.Gui {
 			AddKeyBinding (Key.Enter, Command.Accept);
 		}
 
-		internal Attribute DetermineColorSchemeFor (MenuItem item, int index)
+		internal IAttribute DetermineColorSchemeFor (MenuItem item, int index)
 		{
 			if (item != null) {
 				if (index == current) return ColorScheme.Focus;
@@ -938,7 +938,7 @@ namespace Terminal.Gui {
 			for (int i = 0; i < Menus.Length; i++) {
 				var menu = Menus [i];
 				Move (pos, 0);
-				Attribute hotColor, normalColor;
+				IAttribute hotColor, normalColor;
 				if (i == selected && IsMenuOpen) {
 					hotColor = i == selected ? ColorScheme.HotFocus : ColorScheme.HotNormal;
 					normalColor = i == selected ? ColorScheme.Focus :

--- a/Terminal.Gui/Views/StatusBar.cs
+++ b/Terminal.Gui/Views/StatusBar.cs
@@ -135,7 +135,7 @@ namespace Terminal.Gui {
 			}
 		}
 
-		Attribute ToggleScheme (Attribute scheme)
+		IAttribute ToggleScheme (IAttribute scheme)
 		{
 			var result = scheme == ColorScheme.Normal ? ColorScheme.HotNormal : ColorScheme.Normal;
 			Driver.SetAttribute (result);

--- a/Terminal.Gui/Views/TableView.cs
+++ b/Terminal.Gui/Views/TableView.cs
@@ -538,7 +538,7 @@ namespace Terminal.Gui {
 		/// <param name="cellColor"></param>
 		/// <param name="render"></param>
 		/// <param name="isPrimaryCell"></param>
-		protected virtual void RenderCell (Attribute cellColor, string render,bool isPrimaryCell)
+		protected virtual void RenderCell (IAttribute cellColor, string render,bool isPrimaryCell)
 		{
 			// If the cell is the selected col/row then draw the first rune in inverted colors
 			// this allows the user to track which cell is the active one during a multi cell

--- a/Terminal.Gui/Views/TextView.cs
+++ b/Terminal.Gui/Views/TextView.cs
@@ -1848,7 +1848,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Sets the <see cref="View.Driver"/> to an appropriate color for rendering the given <paramref name="idx"/> of the
-		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(Attribute)"/>
+		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(IAttribute)"/>
 		/// Defaults to <see cref="ColorScheme.Normal"/>.
 		/// </summary>
 		/// <param name="line"></param>
@@ -1860,7 +1860,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Sets the <see cref="View.Driver"/> to an appropriate color for rendering the given <paramref name="idx"/> of the
-		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(Attribute)"/>
+		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(IAttribute)"/>
 		/// Defaults to <see cref="ColorScheme.Focus"/>.
 		/// </summary>
 		/// <param name="line"></param>
@@ -1872,7 +1872,7 @@ namespace Terminal.Gui {
 
 		/// <summary>
 		/// Sets the <see cref="View.Driver"/> to an appropriate color for rendering the given <paramref name="idx"/> of the
-		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(Attribute)"/>
+		/// current <paramref name="line"/>.  Override to provide custom coloring by calling <see cref="ConsoleDriver.SetAttribute(IAttribute)"/>
 		/// Defaults to <see cref="ColorScheme.HotFocus"/>.
 		/// </summary>
 		/// <param name="line"></param>

--- a/UICatalog/Scenarios/GraphViewExample.cs
+++ b/UICatalog/Scenarios/GraphViewExample.cs
@@ -520,11 +520,11 @@ namespace UICatalog.Scenarios {
 		}
 
 		class DiscoBarSeries : BarSeries {
-			private Terminal.Gui.Attribute green;
-			private Terminal.Gui.Attribute brightgreen;
-			private Terminal.Gui.Attribute brightyellow;
-			private Terminal.Gui.Attribute red;
-			private Terminal.Gui.Attribute brightred;
+			private Terminal.Gui.IAttribute green;
+			private Terminal.Gui.IAttribute brightgreen;
+			private Terminal.Gui.IAttribute brightyellow;
+			private Terminal.Gui.IAttribute red;
+			private Terminal.Gui.IAttribute brightred;
 
 			public DiscoBarSeries ()
 			{

--- a/UICatalog/Scenarios/MultiColouredTable.cs
+++ b/UICatalog/Scenarios/MultiColouredTable.cs
@@ -115,7 +115,7 @@ namespace UICatalog.Scenarios {
 		}
 
 		class TableViewColors : TableView {
-			protected override void RenderCell (Terminal.Gui.Attribute cellColor, string render, bool isPrimaryCell)
+			protected override void RenderCell (Terminal.Gui.IAttribute cellColor, string render, bool isPrimaryCell)
 			{
 				int unicorns = render.IndexOf ("unicorns",StringComparison.CurrentCultureIgnoreCase);
 				int rainbows = render.IndexOf ("rainbows", StringComparison.CurrentCultureIgnoreCase);

--- a/UICatalog/Scenarios/SyntaxHighlighting.cs
+++ b/UICatalog/Scenarios/SyntaxHighlighting.cs
@@ -64,9 +64,9 @@ namespace UICatalog.Scenarios {
 		private class SqlTextView : TextView{
 
 			private HashSet<string> keywords = new HashSet<string>(StringComparer.CurrentCultureIgnoreCase);
-			private Attribute blue;
-			private Attribute white;
-			private Attribute magenta;
+			private IAttribute blue;
+			private IAttribute white;
+			private IAttribute magenta;
 
 
 		public void Init()

--- a/UICatalog/Scenarios/TreeViewFileSystem.cs
+++ b/UICatalog/Scenarios/TreeViewFileSystem.cs
@@ -24,8 +24,8 @@ namespace UICatalog.Scenarios {
 		private MenuItem miUnicodeSymbols;
 		private MenuItem miFullPaths;
 		private MenuItem miLeaveLastRow;
-		private Terminal.Gui.Attribute green;
-		private Terminal.Gui.Attribute red;
+		private Terminal.Gui.IAttribute green;
+		private Terminal.Gui.IAttribute red;
 
 		public override void Setup ()
 		{

--- a/UnitTests/AttributeTests.cs
+++ b/UnitTests/AttributeTests.cs
@@ -62,8 +62,6 @@ namespace Terminal.Gui.ConsoleDrivers {
 			Application.Init (driver, new FakeMainLoop (() => FakeConsole.ReadKey (true)));
 			driver.Init (() => { });
 
-			var attr = new Attribute ();
-
 			var value = 42;
 			var fg = new Color ();
 			fg = Color.Red;
@@ -72,12 +70,12 @@ namespace Terminal.Gui.ConsoleDrivers {
 			bg = Color.Blue;
 
 			// Test conversion to int
-			attr = new Attribute (value, fg, bg);
+			var attr = new Attribute (value, fg, bg);
 			int value_implicit = (int)attr.Value;
 			Assert.Equal (value, value_implicit);
 
 			// Test conversion from int
-			attr = value;
+			attr = new Attribute(value);
 			Assert.Equal (value, attr.Value);
 
 			driver.End ();

--- a/UnitTests/BorderTests.cs
+++ b/UnitTests/BorderTests.cs
@@ -121,7 +121,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left;
 					c < frame.Right + drawMarginFrame + sumThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -132,7 +132,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left;
 					c < frame.X - drawMarginFrame - padding.Left; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -143,7 +143,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.Right + drawMarginFrame + padding.Right;
 					c < frame.Right + drawMarginFrame - sumThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -154,7 +154,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left;
 					c < frame.Right + drawMarginFrame + sumThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -165,7 +165,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - padding.Left;
 					c < frame.Right + drawMarginFrame + padding.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -176,7 +176,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - padding.Left;
 					c < frame.X - drawMarginFrame; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -187,7 +187,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.Right + drawMarginFrame;
 					c < frame.Right + drawMarginFrame - padding.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -198,7 +198,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - padding.Left;
 					c < frame.Right + drawMarginFrame + padding.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -223,7 +223,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame;
 					c <= frame.Right + drawMarginFrame - 1; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					var rune = (Rune)driver.Contents [r, c, 0];
 					Assert.Equal (Color.Black, color.Background);
 					if (c == frame.X - drawMarginFrame && r == frame.Y - drawMarginFrame) {
@@ -253,7 +253,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left + effect3DOffset.X;
 					c < frame.Right + drawMarginFrame + sumThickness.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -264,7 +264,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left + effect3DOffset.X;
 					c < frame.X - drawMarginFrame - sumThickness.Left; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -275,7 +275,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.Right + drawMarginFrame + sumThickness.Right;
 					c < frame.Right + drawMarginFrame + sumThickness.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -286,7 +286,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X - drawMarginFrame - sumThickness.Left + effect3DOffset.X;
 					c < frame.Right + drawMarginFrame + sumThickness.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -295,7 +295,7 @@ namespace Terminal.Gui.Core {
 			for (int r = frame.Y; r < frame.Y + frame.Height; r++) {
 				for (int c = frame.X; c < frame.X + frame.Width; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Foreground);
 					Assert.Equal (Color.Black, color.Background);
 				}
@@ -349,7 +349,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X;
 					c < frame.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -360,7 +360,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X;
 					c < Math.Min (frame.X + borderThickness.Left, frame.Right); c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -371,7 +371,7 @@ namespace Terminal.Gui.Core {
 				for (int c = Math.Max (frame.Right - borderThickness.Right, frame.X);
 					c < frame.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -382,7 +382,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X;
 					c < frame.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.Red, color.Background);
 				}
 			}
@@ -393,7 +393,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + borderThickness.Left;
 					c < frame.Right - borderThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -404,7 +404,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + borderThickness.Left;
 					c < Math.Min (frame.X + sumThickness.Left, frame.Right - borderThickness.Right); c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -417,7 +417,7 @@ namespace Terminal.Gui.Core {
 					c < Math.Max (frame.Right - borderThickness.Right, frame.X + sumThickness.Left); c++) {
 
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -428,7 +428,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + borderThickness.Left;
 					c < frame.Right - borderThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Background);
 				}
 			}
@@ -453,7 +453,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + sumThickness.Left;
 					c <= frame.Right - sumThickness.Right - 1; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					var rune = (Rune)driver.Contents [r, c, 0];
 					Assert.Equal (Color.Black, color.Background);
 					if (c == frame.X + sumThickness.Left && r == frame.Y + sumThickness.Top) {
@@ -488,7 +488,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + effect3DOffset.X;
 					c < frame.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -499,7 +499,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + effect3DOffset.X;
 					c < frame.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -510,7 +510,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.Right;
 					c < frame.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -521,7 +521,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + effect3DOffset.X;
 					c < frame.Right + effect3DOffset.X; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.DarkGray, color.Background);
 				}
 			}
@@ -532,7 +532,7 @@ namespace Terminal.Gui.Core {
 				for (int c = frame.X + drawMarginFrame + sumThickness.Left;
 					c < frame.Right - drawMarginFrame - sumThickness.Right; c++) {
 
-					var color = (Attribute)driver.Contents [r, c, 1];
+					var color = new Attribute(driver.Contents [r, c, 1]);
 					Assert.Equal (Color.BrightGreen, color.Foreground);
 					Assert.Equal (Color.Black, color.Background);
 				}

--- a/UnitTests/GraphViewTests.cs
+++ b/UnitTests/GraphViewTests.cs
@@ -124,7 +124,7 @@ namespace Terminal.Gui.Views {
 		/// </summary>
 		/// <param name="expectedLook">Numbers between 0 and 9 for each row/col of the console.  Must be valid indexes of <paramref name="expectedColors"/></param>
 		/// <param name="expectedColors"></param>
-		public static void AssertDriverColorsAre (string expectedLook, Attribute[] expectedColors)
+		public static void AssertDriverColorsAre (string expectedLook, IAttribute[] expectedColors)
 		{
 #pragma warning restore xUnit1013 // Public method should be marked as test
 

--- a/UnitTests/TableViewTests.cs
+++ b/UnitTests/TableViewTests.cs
@@ -566,7 +566,7 @@ namespace Terminal.Gui.Views {
 ";
 			var invertedNormalColor = Application.Driver.MakeAttribute (tv.ColorScheme.Normal.Background, tv.ColorScheme.Normal.Foreground);
 
-			GraphViewTests.AssertDriverColorsAre (expectedColors, new Attribute [] {
+			GraphViewTests.AssertDriverColorsAre (expectedColors, new IAttribute [] {
 				// 0
 				tv.ColorScheme.Normal,				
 				// 1


### PR DESCRIPTION
I made this version to preserve Attribute as a structure for performance. I'd say the biggest changes this will cause is GetAttribute calls return IAttribute. Interfaces cannot have an implicit int cast, but the same operations are still possible using the Value property and one of the constructors for Attribute so I think it's minor and actually easier to read.